### PR TITLE
fix: compatible with frappe dialog email when pre-fill content and get newest content.

### DIFF
--- a/frappe_tinymce/public/js/frappe_tinymce.js
+++ b/frappe_tinymce/public/js/frappe_tinymce.js
@@ -44,15 +44,20 @@ frappe.ui.form.ControlTextEditor = class ControlTextEditor extends frappe.ui.for
         this.activeEditor = tinymce.activeEditor
     }
 
-    set_formatted_input(value){
-        if (this.frm && !this.frm.doc.__setContent){
-            if(value){
-                this.activeEditor.setContent(value)
-            }else{
-                this.activeEditor.setContent("")
+    set_formatted_input(value) {
+        if (this.frm) {
+            if (!this.frm.doc.__setContent) {
+                if (value) {
+                    this.activeEditor.setContent(value)
+                } else {
+                    this.activeEditor.setContent("")
+                }
+                this.frm.doc.__setContent = 1
             }
         }
-        this.frm.doc.__setContent = 1
+    }
 
+    get_input_value() {
+        return this.activeEditor.getContent()
     }
 }


### PR DESCRIPTION
When create a new email, frappe will popup a dialog, if we access form doctype in here will throw undefined exception. Check undefined is necessary. Beside, send email action will call function `get_input_value`, the result will always empty because it use the function in class `ControlCode`. So, the extend class must override it.